### PR TITLE
Add CSV export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,7 @@ python routine_app/daily_routine.py [command] [options]
 - `add <date> <time> <description>`: Add a task for the specified date.
 - `done <date> <index>`: Mark the task at the given index as done.
 - `list [date]`: List tasks for the given date (defaults to today).
+- `export <date> <file>`: Export tasks for the date to a CSV file.
 
 Data is stored in `routines.json` in the project root.
+Exported CSV files can be imported into spreadsheet applications like Google Sheets.

--- a/routine_app/daily_routine.py
+++ b/routine_app/daily_routine.py
@@ -1,4 +1,5 @@
 import json
+import csv
 from datetime import date
 from pathlib import Path
 from typing import List, Dict
@@ -46,6 +47,16 @@ def list_today() -> List[Dict]:
     return list_tasks(date.today().isoformat())
 
 
+def export_tasks(task_date: str, csv_path: str) -> None:
+    """Export tasks for a given date to a CSV file."""
+    tasks = list_tasks(task_date)
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Time", "Description", "Done"])
+        for t in tasks:
+            writer.writerow([t.get("time"), t.get("description"), t.get("done", False)])
+
+
 def main():
     import argparse
 
@@ -64,6 +75,10 @@ def main():
     list_p = subparsers.add_parser("list", help="List tasks for a date")
     list_p.add_argument("date", nargs="?", default=date.today().isoformat())
 
+    export_p = subparsers.add_parser("export", help="Export tasks to CSV")
+    export_p.add_argument("date", help="YYYY-MM-DD")
+    export_p.add_argument("file", help="Output CSV file")
+
     args = parser.parse_args()
 
     if args.command == "add":
@@ -78,6 +93,8 @@ def main():
         for i, t in enumerate(tasks):
             status = "[x]" if t.get("done") else "[ ]"
             print(f"{i}. {status} {t['time']} - {t['description']}")
+    elif args.command == "export":
+        export_tasks(args.date, args.file)
     else:
         parser.print_help()
 

--- a/tests/test_daily_routine.py
+++ b/tests/test_daily_routine.py
@@ -38,3 +38,13 @@ def test_complete_task(tmp_path):
     dr.complete_task("2024-01-01", 0)
     tasks = dr.list_tasks("2024-01-01")
     assert tasks[0]["done"]
+
+
+def test_export_tasks(tmp_path):
+    dr.DATA_FILE = tmp_path / "routines.json"
+    dr.add_task("2024-01-02", "10:00", "Export Task")
+    csv_file = tmp_path / "tasks.csv"
+    dr.export_tasks("2024-01-02", csv_file)
+    content = csv_file.read_text(encoding="utf-8").strip().splitlines()
+    assert content[0] == "Time,Description,Done"
+    assert "Export Task" in content[1]


### PR DESCRIPTION
## Summary
- add `export_tasks` function to create CSV files from tasks
- extend CLI with `export` command
- document CSV export in README
- test new export feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c9f3307c83258caf3cfb1b6379ff